### PR TITLE
Point to Spress 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Marc Pantel <pantel.m@gmail.com>
 
 WORKDIR /tmp
 
-RUN curl -LOS "https://github.com/spress/Spress/releases/download/v1.1.1/spress.phar"
+RUN curl -LOS "https://github.com/spress/Spress/releases/download/v2.0.0/spress.phar"
 RUN chmod +x spress.phar
 RUN mv spress.phar /usr/local/bin/spress
 


### PR DESCRIPTION
Spress 2.0.0 is out.